### PR TITLE
This fix allows Asternet to communicate with Asterisk AMI on Linux.

### DIFF
--- a/AsterNET.NetStandard/Manager/ManagerReader.cs
+++ b/AsterNET.NetStandard/Manager/ManagerReader.cs
@@ -133,7 +133,7 @@ namespace AsterNET.NetStandard.Manager
 				// \n - because not all dev in Digium use \r\n
 				// .Trim() kill \r
 				lock (((ICollection) lineQueue).SyncRoot)
-					while (!string.IsNullOrEmpty(mrReader.lineBuffer) && (idx = mrReader.lineBuffer.IndexOf("\n")) >= 0)
+					while (!string.IsNullOrEmpty(mrReader.lineBuffer) && (idx = mrReader.lineBuffer.IndexOf('\n')) >= 0)
 					{
 						line = idx > 0 ? mrReader.lineBuffer.Substring(0, idx).Trim() : string.Empty;
 						mrReader.lineBuffer = (idx + 1 < mrReader.lineBuffer.Length


### PR DESCRIPTION
If Asternet.NetStandard is used in a project that is hosted on Linux, '\n' must be used instead of "\n".
'\n' also works if the project is hosted on Windows.